### PR TITLE
Implementadas reglas de formularios

### DIFF
--- a/src/components/common/FormularioDatosError.vue
+++ b/src/components/common/FormularioDatosError.vue
@@ -15,6 +15,8 @@
                 class="textAreaError"
                 v-model="descripcion"
                 filled label="Descripción del error"
+                counter
+                :rules="[errorRules.required, errorRules.counter]"
                 auto-grow
                 value=""
                 ></v-textarea>
@@ -57,9 +59,18 @@
                 class="actionForm"
             >
                 <v-spacer></v-spacer>
-                <v-btn color="error" dark @click="closeEditError()"
+                <v-btn
+                class="button"
+                color="error" 
+                dark 
+                @click="closeEditError()"
                 >CANCELAR</v-btn>
-                <v-btn color="success" dark @click="storeErrorData()"
+                <v-btn
+                :disabled="disableAceptarError || descripcion.length == 0"
+                color="success" 
+                :dark="!disableAceptarError"
+                class="button" 
+                @click="storeErrorData()"
                 >ACEPTAR</v-btn>
             </v-card-actions>
             </div>
@@ -85,6 +96,16 @@ import { makeArrayFromApi } from '@/assets/mixins/makeArrayFromApi.js';
         computed: {
             returnError(){
             return this.error;
+            },
+        },
+
+        watch:{
+            descripcion(){
+                if(this.descripcion.length >= 255 || this.descripcion.length == 0){
+                    this.disableAceptarError = true;
+                } else {
+                    this.disableAceptarError = false;
+                }
             },
         },
 
@@ -123,11 +144,17 @@ import { makeArrayFromApi } from '@/assets/mixins/makeArrayFromApi.js';
 
         data(){
             return{
-                descripcion: '',              //Descripcion del error -> recibimos en prop
+                descripcion: '',            //Descripcion del error -> recibimos en prop
                 arrayTemaError:[],          //Array temas error -> obtenidos en getErrorParameters
                 seleccionTemaError: [],     //Seleccion tema error -> valor por defecto y seleccion de tema en el array
                 arrayTipoError: [],         //Array tipos error -> obtenidos en getErrorParameters
                 seleccionTipoError: [],     //Seleccion tipo error -> valor por defecto y seleccion de tipo en el array
+
+                errorRules: {
+                required: value => !!value || 'Este campo es obligatorio.',
+                counter: value => value.length <= 255 || 'Máximo 255 caracteres'
+                },
+                disableAceptarError: false,
             }
         }
     }
@@ -160,8 +187,11 @@ import { makeArrayFromApi } from '@/assets/mixins/makeArrayFromApi.js';
         background-color: #ECEFF1;
     }
 
-
     .formRowTitle {
         margin-top: 0.46rem;
+    }
+
+    .button {
+        font-weight: 400 !important;
     }
 </style>

--- a/src/components/common/FormularioDatosJob.vue
+++ b/src/components/common/FormularioDatosJob.vue
@@ -1,188 +1,187 @@
-<template>  
-      <v-card light width="500">
-        <v-card-title
-        class="titleJobForm"
-        dark
-          >Editar Atributos Job
-          <v-spacer></v-spacer>
-        </v-card-title>
-        <div>
-          <!--TextEditor descripciones error-->
-          <v-col class="bg-gray-200" cols="12">
-            <v-textarea
-              class="textAreaJob"
-              v-model="descJob"
+<template>
+  <v-card>
+    <v-card-title class="titleJobForm" dark
+      >Edición de Job
+      <v-spacer></v-spacer>
+    </v-card-title>
+
+    <div>
+      <!--TextEditor descripciones error-->
+      <v-col cols="12">
+        <v-textarea
+          counter
+          class="textAreaJob"
+          v-model="descJob"
+          dense
+          filled
+          auto-grow
+          :rules="[jobRules.required, jobRules.counter]"
+          label="Descripción del Job"
+        ></v-textarea>
+      </v-col>
+
+      <v-divider></v-divider>
+
+      <v-col cols="12">
+        <v-row class="formRow">
+          <v-col cols="4"> Job Grande: </v-col>
+          <v-col cols="8" class="vColJobGran">
+            <v-switch
+              class="switchBigJob"
+              inset
+              v-model="jobGrande"
+            ></v-switch>
+          </v-col>
+        </v-row>
+
+        <v-row class="formRow">
+          <v-col class="formRowTitle" cols="4"> Expediente </v-col>
+          <v-col cols="8">
+            <v-select
               dense
               filled
-              auto-grow
-              label="Descripción del Job"
-            ></v-textarea>
+              :items="expediente"
+              v-model="expedienteJob"
+            ></v-select>
           </v-col>
+        </v-row>
 
-          <v-spacer ></v-spacer>
-
-          <v-col cols="12">
-            <v-row class="formRow">
-              <v-col 
-              class="formRowTitle"
-              cols="4" > Job Grande: </v-col>
-              <v-col cols="8" style="padding:0rem 0.7rem 1rem; 0rem;">
-                <v-switch
-                  class="switchBigJob"
-                  inset
-                  v-model="jobGrande"
-                ></v-switch>
-              </v-col>
-            </v-row>
-
-            <v-row class="formRow">
-              <v-col 
-              class="formRowTitle"
-              cols="4"> Expediente </v-col>
-              <v-col cols="8">
-                <v-select
-                  dense
-                  filled
-                  :items="expediente"
-                  v-model="expedienteJob"
-                ></v-select>
-              </v-col>
-            </v-row>
-
-            <v-row class="formRow">
-              <v-col 
-              class="formRowTitle"
-              cols="4"> Detectado en: </v-col>
-              <v-col cols="8">
-                <v-select
-                  dense
-                  filled
-                  :items="deteccion"
-                  v-model="deteccionJob"
-                ></v-select>
-              </v-col>
-            </v-row>
-
-            <v-row class="formRow">
-              <v-col 
-              class="formRowTitle"
-              cols="4"> Perfil job: </v-col>
-              <v-col cols="8">
-                <v-select
-                  dense
-                  filled
-                  :items="perfil"
-                  v-model="perfilJob"
-                ></v-select>
-              </v-col>
-            </v-row>
-
-            <v-row class="formRow">
-              <v-col 
-              class="formRowTitle"
-              cols="4"> Gravedad: </v-col>
-              <v-col cols="8">
-                <v-select
-                  dense
-                  filled
-                  :items="gravedad"
-                  v-model="gravedadJob"
-                ></v-select>
-              </v-col>
-            </v-row>
-
-            <v-row class="formRow">
-              <v-col 
-              class="formRowTitle"
-              cols="4"> Asignar a: </v-col>
-              <v-col cols="8">
-                <v-select
-                  dense
-                  filled
-                  :items="asignacion"
-                  v-model="asignacionJob"
-                ></v-select>
-              </v-col>
-            </v-row>
-
-            <v-row
-              v-if="asignacionJob == 'Bandeja de Jobs'"
-              style="margin-bottom: -2.5rem"
-            >
-              <v-col 
-              class="formRowTitle"
-              cols="4"> Enviar a: </v-col>
-              <v-col cols="8">
-                <v-select
-                  dense
-                  filled
-                  :items="tipoBandeja"
-                  v-model="tipoBandejaJob"
-                ></v-select>
-              </v-col>
-            </v-row>
-
-            <v-row
-              v-if="asignacionJob == 'Bandeja de Jobs'"
-              style="margin-bottom: -2.5rem"
-            >
-              <v-col 
-              class="formRowTitle"
-              cols="4"> Operador: </v-col>
-              <v-col cols="8">
-                <v-select
-                  dense
-                  filled
-                  :items="nombreOperador"
-                  v-model="nombreOperadorJob"
-                ></v-select>
-              </v-col>
-            </v-row>
+        <v-row class="formRow">
+          <v-col class="formRowTitle" cols="4"> Detectado en: </v-col>
+          <v-col cols="8">
+            <v-select
+              dense
+              filled
+              :items="deteccion"
+              v-model="deteccionJob"
+            ></v-select>
           </v-col>
+        </v-row>
 
-          <v-spacer></v-spacer>
+        <v-row class="formRow">
+          <v-col class="formRowTitle" cols="4"> Perfil job: </v-col>
+          <v-col cols="8">
+            <v-select
+              dense
+              filled
+              :items="perfil"
+              v-model="perfilJob"
+            ></v-select>
+          </v-col>
+        </v-row>
 
-          <v-card-actions
-            class="actionForm"
-          >
-            <v-spacer></v-spacer>
-            <v-btn color="error" dark @click="closeEditJob()">CANCELAR</v-btn>
-            <v-btn color="success" dark @click="storeJobData()">ACEPTAR</v-btn>
-          </v-card-actions>
-        </div>
-      </v-card>
+        <v-row class="formRow">
+          <v-col class="formRowTitle" cols="4"> Gravedad: </v-col>
+          <v-col cols="8">
+            <v-select
+              dense
+              filled
+              :items="gravedad"
+              v-model="gravedadJob"
+            ></v-select>
+          </v-col>
+        </v-row>
+
+        <v-row class="formRow">
+          <v-col class="formRowTitle" cols="4"> Asignar a: </v-col>
+          <v-col cols="8">
+            <v-select
+              dense
+              filled
+              :items="asignacion"
+              v-model="asignacionJob"
+            ></v-select>
+          </v-col>
+        </v-row>
+
+        <v-row v-if="asignacionJob == 'Bandeja de Jobs'" class="formRow">
+          <v-col class="formRowTitle" cols="4"> Enviar a: </v-col>
+          <v-col cols="8">
+            <v-select
+              dense
+              filled
+              :items="tipoBandeja"
+              v-model="tipoBandejaJob"
+            ></v-select>
+          </v-col>
+        </v-row>
+
+        <v-row v-if="asignacionJob == 'Bandeja de Jobs'" class="formRow">
+          <v-col class="formRowTitle" cols="4"> Operador: </v-col>
+          <v-col cols="8">
+            <v-select
+              dense
+              filled
+              :items="nombreOperador"
+              v-model="nombreOperadorJob"
+            ></v-select>
+          </v-col>
+        </v-row>
+      </v-col>
+
+      <v-card-actions class="actionForm">
+        <v-spacer></v-spacer>
+        <v-btn 
+          class="button"
+          color="error" 
+          dark 
+          @click="closeEditJob()"
+        > 
+        CANCELAR
+        </v-btn>
+        <v-btn
+          class="button"
+          color="success"
+          :dark="!disableAceptarJob"
+          @click="storeJobData()"
+          :disabled="disableAceptarJob || descJob.length == 0"
+          >ACEPTAR
+        </v-btn>
+      </v-card-actions>
+    </div>
+  </v-card>
 </template>
 
 <script>
-import axios from 'axios';
-import {makeArrayFromApi} from '@/assets/mixins/makeArrayFromApi.js';
+import axios from "axios";
+import { makeArrayFromApi } from "@/assets/mixins/makeArrayFromApi.js";
 
 export default {
   name: "FormularioDatosJob",
-
   mixins: [makeArrayFromApi],
 
-  mounted(){
-      this.getJobParameters();
+  mounted() {
+    this.getJobParameters();
   },
 
   props: ["job"],
 
-        computed: {
-            returnJob(){
-            return this.job;
-            },
-        },
+  computed: {
+    returnJob() {
+      return this.job;
+    },
+  },
+
+  watch: {
+    descJob() {
+      if (this.descJob.length >= 255 || this.descJob.length == 0) {
+        this.disableAceptarJob = true;
+      } else {
+        this.disableAceptarJob = false;
+      }
+    },
+  },
 
   methods: {
     dummy() {
       //
     },
-    closeEditJob(){
+
+    closeEditJob() {
       this.$emit("closeEditJob", false);
     },
 
-    storeJobData(){
+    storeJobData() {
       this.job.asignacion_job = this.asignacionJob;
       this.job.descripcion = this.descJob;
       this.job.deteccion_job = this.deteccionJob;
@@ -198,17 +197,43 @@ export default {
       this.closeEditJob();
     },
 
-    getJobParameters(){
-      axios.get(`${process.env.VUE_APP_API_ROUTE}/jobParameters`).then((data) => {
+    getJobParameters() {
+      axios
+        .get(`${process.env.VUE_APP_API_ROUTE}/jobParameters`)
+        .then((data) => {
           this.objeto = data.data;
           //makeArrayFromApi (objetoAPI, arrayCrear, columnaBD)
-          this.makeArrayFromApi(this.objeto.expediente,this.expediente, 'expediente')
-          this.makeArrayFromApi(this.objeto.asignacion,this.asignacion, 'asignacion')
-          this.makeArrayFromApi(this.objeto.deteccion,this.deteccion, 'deteccion')
-          this.makeArrayFromApi(this.objeto.gravedad,this.gravedad, 'gravedad')
-          this.makeArrayFromApi(this.objeto.operador,this.nombreOperador, 'nombre_operador')
-          this.makeArrayFromApi(this.objeto.perfilJob,this.perfil, 'arreglo')                  
-          this.makeArrayFromApi(this.objeto.tipoBandeja,this.tipoBandeja, 'tipo_bandeja')
+          this.makeArrayFromApi(
+            this.objeto.expediente,
+            this.expediente,
+            "expediente"
+          );
+          this.makeArrayFromApi(
+            this.objeto.asignacion,
+            this.asignacion,
+            "asignacion"
+          );
+          this.makeArrayFromApi(
+            this.objeto.deteccion,
+            this.deteccion,
+            "deteccion"
+          );
+          this.makeArrayFromApi(
+            this.objeto.gravedad,
+            this.gravedad,
+            "gravedad"
+          );
+          this.makeArrayFromApi(
+            this.objeto.operador,
+            this.nombreOperador,
+            "nombre_operador"
+          );
+          this.makeArrayFromApi(this.objeto.perfilJob, this.perfil, "arreglo");
+          this.makeArrayFromApi(
+            this.objeto.tipoBandeja,
+            this.tipoBandeja,
+            "tipo_bandeja"
+          );
 
           //Valores preasignados del job a editar
           this.descJob = this.job.descripcion;
@@ -220,78 +245,88 @@ export default {
           this.asignacionJob = this.job.asignacion_job;
           this.tipoBandejaJob = this.job.tipo_bandeja;
           this.nombreOperadorJob = this.job.nombre_operador;
-          })
+        });
     },
   },
 
   data() {
     return {
       //FORMULARIO ALTA JOB
-      editJob: false,                   //Visibilidad ventana editar atributos
-      descJob: "",                      //TextArea Descripcion Job
-      jobGrande: false,                 //Valor
+      editJob: false, //Visibilidad ventana editar atributos
+      descJob: "", //TextArea Descripcion Job
+      jobGrande: false, //Valor
       expediente: [],
       expedienteJob: [],
-      deteccion: [],                    //Array desde BD llenar en initialize
-      deteccionJob: [],                 //Toma por defecto primer valor
-      perfil: [],                       //Array desde BD llenar en initialize
+      deteccion: [], //Array desde BD llenar en initialize
+      deteccionJob: [], //Toma por defecto primer valor
+      perfil: [], //Array desde BD llenar en initialize
       perfilJob: [],
-      gravedad: [],                     //Array desde BD llenar en initialize
+      gravedad: [], //Array desde BD llenar en initialize
       gravedadJob: [],
-      asignacion: [],                   //Array desde BD llenar en initialize
+      asignacion: [], //Array desde BD llenar en initialize
       asignacionJob: [],
-      tipoBandeja: [],                  //Array desde BD llenar en initialize
+      tipoBandeja: [], //Array desde BD llenar en initialize
       tipoBandejaJob: [],
-      nombreOperador: [],               //Array desde BD llenar en initialize
+      nombreOperador: [], //Array desde BD llenar en initialize
       nombreOperadorJob: [],
+      jobRules: {
+        required: (value) => !!value || "Este campo es obligatorio.",
+        counter: (value) => value.length <= 255 || "Máximo 255 caracteres",
+      },
+      disableAceptarJob: true,
     };
   },
 };
 </script>
 
 <style scoped>
-      /*FORMULARIOS ALTA ERROR JOB */
-    .titleErrorForm {
-        background-color: #E53935;
-        color: white;
-        font-weight: 400 !important;
-    }
+/*FORMULARIOS ALTA ERROR JOB */
+.titleErrorForm {
+  background-color: #e53935;
+  color: white;
+  font-weight: 400 !important;
+}
 
-    .containerForm {
-        font-weight: 400 !important;
-    }
+.containerForm {
+  font-weight: 400 !important;
+}
 
-    .textAreaError {
-        margin-top: 0.5rem;
-    }
+.titleJobForm {
+  background-color: #039be5;
+  color: white;
+  font-weight: 400 !important;
+}
 
-    .titleJobForm {
-        background-color: #039BE5;
-        color: white;
-        font-weight: 400 !important;
-    }
+.formRow {
+  margin-top: 0.5rem;
+  margin-bottom: -2.5rem;
+}
 
-    .formRow {
-        margin-top: 0.5rem;
-        margin-bottom: -2.5rem
-    }
-    
-    .switchBigJob {
-        margin-top: 0.2rem;
-        margin-bottom: 0.2rem;
-    }
+.switchBigJob {
+  margin-top: 0.2rem;
+  margin-bottom: 0.2rem;
+  padding-top: 0.5rem;
+}
 
-    .actionForm {
-        margin-top: 1rem;
-        padding: 1rem;
-        background-color: #ECEFF1;
-    }
+.actionForm {
+  margin-top: 1rem;
+  padding: 1rem;
+  background-color: #eceff1;
+}
 
-    .textAreaJob {
-        margin-top: 0.5rem;
-    }
+.textAreaJob {
+  margin: 0.5rem 0rem -1rem 0rem;
+}
 
-    .formRowTitle {
-        margin-top: 0.46rem;
-    }
+.formRowTitle {
+  margin-top: 0.46rem;
+}
+
+.button{
+  font-weight: 400 !important;
+}
+
+.vColJobGran {
+  padding: 0rem 0.7rem 1rem 0.8rem;
+}
 </style>

--- a/src/components/common/Map.vue
+++ b/src/components/common/Map.vue
@@ -122,6 +122,7 @@
                         v-if="atribute.error != null"
                     >
                         <vl-overlay
+                        class="showIdErrorContainer"
                         :position="atribute.geometria_json.coordinates"
                         :offset="[-48, -45]">
                             <p>
@@ -251,9 +252,11 @@
                         <!--TextEditor descripciones error-->
                         <v-col cols="12">
                         <v-textarea
+                            counter
                             class="textAreaJob"
                             v-model="descJob"
                             dense filled auto-grow
+                            :rules="[jobRules.required, jobRules.counter]"
                             label="Descripción del Job"
                         ></v-textarea>
                         </v-col>
@@ -264,10 +267,9 @@
                         <v-row class="formRow">
                             <v-col 
                             cols="4"> Job Grande: </v-col>
-                            <v-col cols="8" style="padding:0rem 0.7rem 1rem; 0rem;">
+                            <v-col cols="8" class="vColJobGran">
                                 <v-switch
                                 class="switchBigJob"
-                                style="padding-top:0.5rem;"
                                 inset
                                 v-model="jobGrande"
                                 ></v-switch>
@@ -376,9 +378,18 @@
                             class="actionForm"
                         >
                             <v-spacer></v-spacer>
-                            <v-btn color="error" dark @click="abortInsertion('jobs')"
+                            <v-btn
+                            class="button" 
+                            color="error" 
+                            dark 
+                            @click="abortInsertion('jobs')"
                             >CANCELAR</v-btn>
-                            <v-btn color="success" dark @click="storeAttrbJobs"
+                            <v-btn 
+                            class="button"
+                            :disabled="disableAceptarJob || descJob == null"
+                            color="success" 
+                            :dark="!disableAceptarJob"
+                            @click="storeAttrbJobs"
                             >ACEPTAR</v-btn>
                         </v-card-actions>
                     </div>
@@ -405,6 +416,8 @@
                         <v-textarea
                         class="textAreaError"
                         v-model="descError"
+                        counter
+                        :rules="[errorRules.required, errorRules.counter]"
                         filled label="Descripción del error"
                         auto-grow
                         value=""
@@ -447,9 +460,18 @@
                         class="actionForm"
                     >
                         <v-spacer></v-spacer>
-                        <v-btn color="error" dark @click="abortInsertion('errores')"
+                        <v-btn 
+                        class="button"
+                        color="error" 
+                        dark
+                        @click="abortInsertion('errores')"
                         >CANCELAR</v-btn>
-                        <v-btn color="success" dark @click="storeAttrbErrors"
+                        <v-btn
+                        class="button"
+                        :disabled="disableAceptarError || descError == null"
+                        color="success" 
+                        :dark="!disableAceptarError"
+                        @click="storeAttrbErrors"
                         >ACEPTAR</v-btn>
                     </v-card-actions>
                     </div>
@@ -553,9 +575,31 @@
                     class="actionForm"
                 >
                 <v-spacer></v-spacer>
-                    <v-btn color="error" elevation="3" @click="closeWindowInfoJob()">CANCELAR</v-btn>
-                    <v-btn :disabled="modoMapa == 'visualizar'" color="primary" elevation="3" @click="openFormEditJob()">EDITAR</v-btn>
-                    <v-btn color="success" elevation="3" @click="updateEditedJob()">ACEPTAR</v-btn>
+                    <v-btn
+                    class="button"
+                    color="error" 
+                    elevation="3" 
+                    @click="closeWindowInfoJob()"
+                    >
+                    CANCELAR
+                    </v-btn>
+                    <v-btn
+                    class="button" 
+                    :disabled="modoMapa == 'visualizar'" 
+                    color="primary" 
+                    elevation="3" 
+                    @click="openFormEditJob()"
+                    >
+                    EDITAR
+                    </v-btn>
+                    <v-btn
+                    class="button" 
+                    color="success" 
+                    elevation="3" 
+                    @click="updateEditedJob()"
+                    >
+                    ACEPTAR
+                    </v-btn>
                 </v-card-actions>
             </v-card>
         </v-dialog>
@@ -610,9 +654,31 @@
                 class="actionForm"
                 >
                 <v-spacer></v-spacer>
-                    <v-btn color="error" elevation="3" @click="ventanaInfoError = false">CANCELAR</v-btn>
-                    <v-btn :disabled="modoMapa == 'visualizar'" color="primary" elevation="3" @click="openFormEditError()">EDITAR</v-btn>
-                    <v-btn color="success" elevation="3" @click="updateEditedError()">ACEPTAR</v-btn>
+                    <v-btn
+                    class="button" 
+                    color="error" 
+                    elevation="3" 
+                    @click="ventanaInfoError = false"
+                    >
+                    CANCELAR
+                    </v-btn>
+                    <v-btn
+                    class="button" 
+                    :disabled="modoMapa == 'visualizar'" 
+                    color="primary" 
+                    elevation="3" 
+                    @click="openFormEditError()"
+                    >
+                    EDITAR
+                    </v-btn>
+                    <v-btn
+                    class="button"
+                    color="success" 
+                    elevation="3" 
+                    @click="updateEditedError()"
+                    >
+                    ACEPTAR
+                    </v-btn>
                 </v-card-actions>
             </v-card>
         </v-dialog>
@@ -686,6 +752,22 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
         },
 
         watch:{
+            descError(){
+                if(this.descError.length >= 255 || this.descError.length == 0){
+                    this.disableAceptarError = true;
+                } else {
+                    this.disableAceptarError = false;
+                }
+            },
+
+            descJob(){
+                if(this.descJob.length >= 255 || this.descJob.length == 0){
+                    this.disableAceptarJob = true;
+                } else {
+                    this.disableAceptarJob = false;
+                }
+            },
+
             jobs(){
                 if(this.jobs.length != 0 && this.toolActive == 'drawJobs'){
                     this.editJob = true
@@ -1327,7 +1409,7 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
 
             //FORMULARIO ALTA JOB   
             editJob: false,             //Visibilidad ventana editar atributos
-            descJob: '',                //TextArea Descripcion Job
+            descJob: null,                //TextArea Descripcion Job
             jobGrande: false,           //Valor
             expediente:[],
             expedienteJob:[],
@@ -1343,14 +1425,24 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
             tipoBandejaJob: [],
             nombreOperador: [],         //Array desde BD llenar en initialize
             nombreOperadorJob: [],
+            jobRules: {
+                required: value => !!value || 'Este campo es obligatorio.',
+                counter: value => value.length <= 255 || 'Máximo 255 caracteres'
+            },
+            disableAceptarJob: true,
 
             //FORMULARIO ALTA ERROR
             editError: false,
-            descError: '',
+            descError: null,
             temaError:[],
             selectTema: [],
             tipoError: [],
             selectTipoError: [],
+            errorRules: {
+                required: value => !!value || 'Este campo es obligatorio.',
+                counter: value => value.length <= 255 || 'Máximo 255 caracteres'
+            },
+            disableAceptarError: true,
             
 
             //MENSAJES FLOTANTES         
@@ -1462,7 +1554,7 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
     }
 
     .textAreaError {
-        margin-top: 0.5rem;
+        margin: 0.5rem 0rem -1.8rem 0rem;
     }
 
     .titleJobForm {
@@ -1479,6 +1571,7 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
     .switchBigJob {
         margin-top: 0.2rem;
         margin-bottom: 0.2rem;
+        padding-top: 0.5rem;
     }
 
     .actionForm {
@@ -1488,11 +1581,19 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
     }
 
     .textAreaJob {
-        margin-top: 0.5rem;
+        margin: 0.5rem 0rem -1rem 0rem;
     }
 
     .formRowTitle {
         margin-top: 0.46rem;
+    }
+
+    .button {
+        font-weight: 400 !important;
+    }
+
+    .vColJobGran {
+        padding: 0rem 0.7rem 1rem 0.8rem;
     }
 
     /*MENSAJES DE ALERTA*/
@@ -1508,6 +1609,16 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
     .alertActions {
         height: 100%;
         margin: auto;
+    }
+
+    /*MOSTRAR ID ERROR EN MAPA */
+    .showIdErrorContainer {
+        font-size:90%;
+        height: 2rem;
+        padding: 0.35rem 0.5rem 0rem 0.5rem;
+        background-color: white;
+        border-radius: 8px;
+        box-shadow: 0px 1px 5px 2px gray;
     }
 
 </style>

--- a/src/components/generadorJobs/ErroresNoAsign.vue
+++ b/src/components/generadorJobs/ErroresNoAsign.vue
@@ -71,7 +71,7 @@
           </template>
 
           <template v-slot:no-data>
-            <v-btn color="primary" @click="initialize">Reset</v-btn>
+            <NoData :mensaje="noDataMensaje" :opcion="noDataOpcion"></NoData>
           </template>
 
           <template v-slot:[`item.estado`]="{ item }">
@@ -102,11 +102,13 @@
 import axios from "axios";
 import { getColor } from "@/assets/mixins/getColor.js";
 import { generarJobError } from '@/assets/mixins/generarJobError';
+import NoData from "@/components/common/NoData";
 
 
 export default {
   name: "ErroresNoAsign",
   mixins: [getColor, generarJobError],
+  components: {NoData,},
 
   data: () => ({
     dialog: false,
@@ -146,6 +148,10 @@ export default {
     showMessage: false,
     message: '',
     messageType: '',
+
+    //NO DATA SLOT
+    noDataMensaje: 'En estos momentos no existen Errores sin asignar',
+    noDataOpcion: 'Puedes encontrar nuevos errores haciendo una revisión visual en Alta de Jobs / Errores',
   }),
 
   computed: {

--- a/src/components/generadorJobs/JobsTriajeGJ.vue
+++ b/src/components/generadorJobs/JobsTriajeGJ.vue
@@ -131,16 +131,7 @@
           </template>
 
           <template v-slot:no-data>
-            <div>
-                <v-progress-circular
-                  :size="70"
-                  :width="7"
-                  color="blue"
-                  indeterminate
-                ></v-progress-circular>
-                <br/>
-                <h2>Recuperando Jobs desde la base de datos ... por favor espere.</h2>
-            </div>
+            <NoData :mensaje="noDataMensaje" :opcion="noDataOpcion"></NoData>
           </template>
 
           <template v-slot:[`item.estado`]="{ item }">
@@ -235,7 +226,8 @@ import axios from "axios";
 import { getColor } from "@/assets/mixins/getColor.js";
 import { generarJobError } from '@/assets/mixins/generarJobError';
 import EditarJob from '@/components/generadorJobs/EditarJob.vue';
-import { stringifyJobGeometry } from '@/assets/mixins/stringifyJobGeometry';
+import { stringifyJobGeometry } from '@/assets/mixins/stringifyJobGeometry'
+import NoData from "@/components/common/NoData";
 
 
 export default {
@@ -243,6 +235,7 @@ export default {
   mixins: [getColor, generarJobError, stringifyJobGeometry],
   components: {
     EditarJob,
+    NoData,
   },
 
   data: () => ({
@@ -294,6 +287,10 @@ export default {
       observaciones: null,
       finalizado: null,
     }],
+
+     //NO DATA SLOT
+    noDataMensaje: 'En estos momentos no existen Jobs que requieran triaje.',
+    noDataOpcion: 'Echa un vistazo a los errores sin asignar por si puedes generar nuevos Jobs.',
   }),
 
   watch: {

--- a/src/components/generadorJobs/NuevoExpediente.vue
+++ b/src/components/generadorJobs/NuevoExpediente.vue
@@ -8,7 +8,12 @@
           <v-btn class="newExpBtn" color="error" dark @click="closeExpediente"
             >CANCELAR</v-btn
           >
-          <v-btn class="newExpBtn" color="success" dark @click="saveExpediente"
+          <v-btn 
+          :disabled="returnObservacionesLength() > 255"
+          class="newExpBtn" 
+          color="success" 
+          dark 
+          @click="saveExpediente"
             >ACEPTAR</v-btn
           >
         </v-card-actions>
@@ -33,6 +38,10 @@
             <div>
               <TextEditor @editor="storeObservationsExp"></TextEditor>
             </div>
+            <div class="obsLengthContainer">
+              <h5 v-if="returnObservacionesLength()<=255" class="obsLengthOK">{{returnObservacionesLength()}}</h5>
+              <h5 v-else class="obsLengthERR">{{returnObservacionesLength()}}</h5>
+            </div>
           </v-col>
         </v-row>
 
@@ -54,7 +63,7 @@
                   locale="es-ES"
                   :first-day-of-week="1"
                   :show-current="false"
-                  width="318"
+                  class="widthCal"
                   color="green"
                   v-model="fechaInicio"
                 ></v-date-picker>
@@ -79,7 +88,7 @@
               locale="es-ES"
               :first-day-of-week="1"
               :show-current="false"
-              width="318"
+              class="widthCal"
               color="red"
               v-model="fechaFin"
             ></v-date-picker>
@@ -130,10 +139,25 @@ export default {
     this.retrieveExpFromBD();
   },
 
+  watch:{
+    observaciones(){
+      console.log(this.observaciones)
+      if(this.observaciones.length > 255){
+        //
+      }
+    }
+  },
+
   methods: {
     initializeParameters() {
-      this.nExp = "";
+      this.nExp = null;
       this.storeObservationsExp("");
+    },
+
+    returnObservacionesLength(){
+      let longitudCadena = this.observaciones.replace(/<[^>]*>/g, '')
+      longitudCadena = longitudCadena.length;
+      return longitudCadena;
     },
 
     closeExpediente() {
@@ -229,7 +253,7 @@ export default {
 
       fechaFin: "",
 
-      observaciones: "",
+      observaciones: null,
       nExp: "",
       expedientesBD: [],
 
@@ -245,7 +269,7 @@ export default {
       modal: false,
 
       rules: {
-        required: (value) => !!value || "Obligatorio.",
+        required: (value) => !!value || "Este campo es obligatorio.",
         formNumExp: (value) =>
           value.length == 13 || "El formato debe ser AAAA_00000000",
       },
@@ -257,7 +281,7 @@ export default {
 <style scoped>
 .newExpContainer {
   width: 80vw;
-  max-width: 715px;
+  max-width: 735px;
   max-height: 95vh;
   overflow-y: auto;
 }
@@ -317,4 +341,24 @@ h3 {
 .oblText {
   margin-top: 1rem;
 }
+
+.obsLengthOK {
+  display: block;
+  text-align: right;
+  font-weight: 400 !important;
+  margin-right: 0.5rem;
+}
+
+.obsLengthERR {
+  display: block;
+  text-align: right;
+  font-weight: 400 !important;
+  margin-right: 0.5rem;
+  color:red;
+}
+
+.widthCal {
+  width: 100vh;
+}
+
 </style>


### PR DESCRIPTION
Implementadas reglas para los formularios de alta de job y errores, asi como los respectivos formularios de edición.

Las reglas activas hasta el momento controlan tanto que ciertos campos no estén vacíos como la longitud de los mismos para evitar errores al hacer la inserción en la base de datos. 

Se han corregido defectos menores en los estilos CSS.