### PR TITLE
Panel ver jobs operadores y funciones de bandeja añadidas

### DIFF
--- a/src/assets/mixins/devuelveProcesos.js
+++ b/src/assets/mixins/devuelveProcesos.js
@@ -1,0 +1,12 @@
+export const devuelveProcesos = {
+    
+    created(){
+        this.devuelveProcesos();
+    },
+
+    methods: {
+        devuelveProcesos(){
+            console.log("hello world")
+        },
+    },
+}

--- a/src/assets/mixins/generarJobError.js
+++ b/src/assets/mixins/generarJobError.js
@@ -72,7 +72,7 @@ export const generarJobError = {
                     for (this.errorIndex in errores){
                         //Definimos objeto error
                         this.actualizarError = {
-                            nuevoEstado: "Pendiente_solución",
+                            nuevoEstado: "Pendiente solución",
                             id_error: errores[this.errorIndex].id_error,
                         };
 
@@ -85,7 +85,6 @@ export const generarJobError = {
                             return enviarDatos;
                         } else {
                             //Grabar en base de datos
-                            console.log("estoy enviando error aqui", this.actualizarError)
                             axios
                             .put(`${process.env.VUE_APP_API_ROUTE}/cambioEstadosError`, this.actualizarError)
                             .then(() => {

--- a/src/assets/mixins/getColor.js
+++ b/src/assets/mixins/getColor.js
@@ -12,7 +12,7 @@ export const getColor = {
             else if (estado == 'Solucionada') return '#009933';             //verde
 
             else if (estado == 'Marcado') return '#d0e4f5';                 //azul claro
-            else if (estado == 'Pendiente solucion') return '#ffcc00';      //amarillo
+            else if (estado == 'Pendiente solución') return '#ffcc00';      //amarillo
             else if (estado == 'Solucionado') return '#009933';             //verde
             else if (estado == 'Desestimado') return '#0066ff';             //azul
             else if (estado == 'Devuelto') return '#f54b42';                //rojo

--- a/src/components/common/Logger.vue
+++ b/src/components/common/Logger.vue
@@ -7,7 +7,7 @@
         <v-card-title class="processTitle">LOG DEL JOB</v-card-title>
         <v-list three-line>
           <template v-for="item in log">
-            <v-list-item :key="item.hora" :class="item.class">
+            <v-list-item :key="item.id_log" :class="item.class">
               <v-list-item-avatar>
                 <v-icon :title="item.procDesc" :class="item.claseProceso" dark>
                   {{ item.icon }}
@@ -90,9 +90,11 @@
                 <div class="errorsTitle">
                   <h2>Errores</h2>
                   <v-spacer></v-spacer>
-                  <v-alert dense outlined class="alertErrors" type="error">
-                    El job aun tiene errores pendientes de solución
-                  </v-alert>
+                  <div v-if="errores.length != 0">
+                    <v-alert dense outlined class="alertErrors" type="error">
+                      El job aun tiene errores pendientes de solución
+                    </v-alert>
+                  </div>
                 </div>
                 <v-data-table
                   :headers="errorHeaders"
@@ -103,6 +105,10 @@
                     <v-chip :color="getColor(item.estado)" dark>
                       {{ item.estado }}
                     </v-chip>
+                  </template>
+
+                  <template v-slot:no-data>
+                    Este job no contiene errores asociados
                   </template>
                 </v-data-table>
               </v-card>
@@ -151,15 +157,9 @@ export default {
     },
 
     actualizarInfo() {
-      console.log("actualizar es->", this.actualizarInfo);
       if (this.actualizarInfo == true) {
-        console.log("ejecuto initialize por actualizacion info");
         this.initialize();
       }
-    },
-
-    log() {
-      console.log("el log cambio");
     },
   },
 
@@ -189,6 +189,7 @@ export default {
       for (this.index in log) {
         this.arrayFecha = log[this.index].fecha.split("T");
         this.logNewEntry = {
+          id: log[this.index].id_log,
           claseProceso: "green",
           class: "",
           icon: this.getLogIcons(log[this.index].codigo),
@@ -274,5 +275,6 @@ h2 {
 
 .errorsTitle {
   display: flex;
+  height: 2.8rem;
 }
 </style>

--- a/src/components/common/Map.vue
+++ b/src/components/common/Map.vue
@@ -1409,7 +1409,7 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
 
             //FORMULARIO ALTA JOB   
             editJob: false,             //Visibilidad ventana editar atributos
-            descJob: null,                //TextArea Descripcion Job
+            descJob: '',              //TextArea Descripcion Job
             jobGrande: false,           //Valor
             expediente:[],
             expedienteJob:[],
@@ -1433,7 +1433,7 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
 
             //FORMULARIO ALTA ERROR
             editError: false,
-            descError: null,
+            descError: '',
             temaError:[],
             selectTema: [],
             tipoError: [],

--- a/src/components/common/VerJob.vue
+++ b/src/components/common/VerJob.vue
@@ -1,0 +1,384 @@
+<template>
+  <div>
+    <!--TOOLBAR SUPERIOR -->
+    <v-toolbar dark color="primary">
+      <v-btn icon dark @click="closeDialog"><v-icon>mdi-close</v-icon></v-btn>
+      <v-toolbar-title
+      class="editJobTitle"
+        >JOB - {{ job.job }}</v-toolbar-title
+      >
+    </v-toolbar>
+
+    <!--MAIN-->
+    <template>
+      <v-card>
+        <v-tabs
+        fixed-tabs 
+        background-color="#0341a6" 
+        dark
+        v-model="activeTab">
+          <v-tab 
+          class="tab"
+          :key="1" 
+          @click="activateMap(false)"
+          >Datos del Job
+          </v-tab>
+          <v-tab 
+          class="tab"
+          :key="2"
+          @click="activateMap(true)"
+          >Localización en el Mapa
+          </v-tab>
+          <v-tab
+          class="tab"
+          :key="3" 
+          @click="activateMap(false)"
+          >Proceso
+          </v-tab>
+          <v-tabs-slider color="#76aff5"></v-tabs-slider>
+          
+          <!--DATOS DEL JOB-->
+          <v-tab-item>  
+            <v-card class="card" flat>
+              <div class="dataTable">
+                <h2>Jobs</h2>
+                <v-data-table
+                  :headers="jobHeaders"
+                  :items="datosJob"
+                  hide-default-footer
+                >
+                  <template v-slot:[`item.estado`]="{ item }">
+                    <v-chip :color="getColor(item.estado)" dark>
+                      {{ item.estado }}
+                    </v-chip>
+                  </template>
+                </v-data-table>
+              </div>
+
+              <div class="dataTable">
+                <h2>Errores Asociados</h2>
+                  <v-data-table
+                    calculate-widths
+                    :headers="errorHeaders"
+                    :items="errores"
+                    item-key="error"
+                    hide-default-footer
+                    >
+                    <template v-slot:[`item.estado`]="{ item }">
+                      <v-chip :color="getColor(item.estado)" dark>
+                        {{ item.estado }}
+                      </v-chip>
+                    </template>
+
+                    <template v-slot:no-data>
+                      <h2>Este Job no tiene errores asociados</h2>
+                    </template>
+
+                    <template v-slot:[`item.actions`]="{ item }">
+                      <v-btn 
+                      title="Eliminar Error" 
+                      icon 
+                      dark>
+                        <v-icon @click="confirmDelete(item)">
+                          mdi-trash-can
+                        </v-icon>
+                      </v-btn>
+                    </template>
+                  </v-data-table>
+              </div>
+            </v-card>
+          </v-tab-item>
+
+          <!--LOCALIZACIÓN EN EL MAPA-->
+          <v-tab-item>
+            <v-card flat style="height:86vh">
+              <Map
+                v-if="mapIsActive == true"
+                modoMapa="visualizar"
+                :jobsRecibidos="editandoJob"
+                :erroresRecibidos="errores"
+              >
+              </Map>
+            </v-card>
+          </v-tab-item>
+          <!-- FIN LOCALIZACION EN EL MAPA -->
+
+          <!--PROCESO-->
+          <v-tab-item>
+            <v-card class="card" flat>
+              <Logger
+                :jobsRecibidos="editandoJob"
+                :erroresRecibidos="errores"
+              ></Logger>
+            </v-card>
+          </v-tab-item>
+          <!--PROCESO-->
+        </v-tabs>
+
+        <!-- ALERTA DATOS SIN GUARDAR (lo utilizamos también en mapa ¿sacar a componente? ) -->
+        <v-overlay :value="showAlert">
+            <v-card class="alertCard">
+              <h1 class="alertCardTitle">ATENCIÓN</h1>
+              <h4>
+                Existen datos sin guardar ¿desea cerrar sin guardar los cambios?
+              </h4>
+              <v-card-actions>
+                <div class="alertButtonGroup">
+                  <v-btn
+                    class="alertButton errorBtn"
+                    dark
+                    text
+                    @click="showAlert = false"
+                    >CANCELAR</v-btn
+                  >
+                  <v-btn
+                    class="alertButton generateBtn"
+                    dark
+                    text
+                    @click="closeWithoutSave()"
+                    >OK</v-btn
+                  >
+                </div>
+              </v-card-actions>
+            </v-card>
+          </v-overlay>
+
+        <!-- AVISO ELIMINAR ERRORES -->
+        <v-overlay :value="showAlertError">
+          <v-card class="alertCard">
+            <h1 class="alertCardTitle">ATENCIÓN</h1>
+            <h4>Esto borrara el error.</h4>
+            <h4>El borrado es permanente y <b>no puede deshacerse</b>.</h4>
+            <br/>
+            <h3><b>¿Desea continuar?</b></h3>
+            <v-card-actions>
+              <div class="alertButtonGroup">
+                <v-btn
+                class="alertButton errorBtn"
+                dark
+                text
+                @click="showAlertError = false"
+                >
+                CANCELAR
+                </v-btn>
+                <v-btn
+                class="alertButton generateBtn"
+                dark
+                text
+                @click="deleteError(errorBorrar)"
+                >
+                OK
+                </v-btn>
+              </div>
+            </v-card-actions>
+          </v-card>
+        </v-overlay>
+
+        <!--MENSAJES DE INFORMACION-->
+        <v-overlay :value="showMessage">
+          <v-alert
+            :color="messageType"
+            dark
+            border="top"
+            icon="mdi-alert-circle-outline"
+            transition="scale-transition"
+          >
+            {{ message }}
+          </v-alert>
+        </v-overlay>
+      </v-card>
+    </template>
+  </div>
+</template>
+
+<script>
+import { getColor } from "@/assets/mixins/getColor";
+import { generarJobError } from "@/assets/mixins/generarJobError";
+import { stringifyJobGeometry } from "@/assets/mixins/stringifyJobGeometry";
+import { stringifyErrorGeometry } from "@/assets/mixins/stringifyErrorGeometry";
+
+import axios from "axios";
+import Map from "@/components/common/Map";
+import Logger from "@/components/common/Logger";
+
+export default {
+  mixins: [
+    getColor,
+    generarJobError,
+    stringifyJobGeometry,
+    stringifyErrorGeometry,
+  ],
+
+  props: ["job", "error", "center"],
+
+  computed: {
+    returnJob() {
+      return this.job;
+    },
+  },
+
+  name: "EditarJob",
+
+  components: {
+    Map,
+    Logger,
+  },
+
+  created() {
+    this.initialize();
+  },
+
+  watch: {
+    job() {
+      //vuelve a lanzar el initialize cuando detecta un cambio de job
+      if (this.job.job) {
+        this.initialize();
+        //es necesario para poder mutar la propiedad recibida "job"
+        this.editandoJob = this.job;
+      }
+    },
+  },
+
+  methods: {
+    datosJobToDataTable() {
+      //caso edicion devuelve arrays hay que convertir a objeto
+      if (this.editandoJob.length > 0) {
+        this.editandoJob = this.editandoJob[0];
+        //añadimos atributos
+        this.editandoJob.geometria = this.stringifyJobGeometry(
+          this.editandoJob.geometria_json
+        );
+      }
+      this.datosJob = [this.editandoJob];
+    },
+
+    activateMap(active) {
+      this.mapIsActive = active;
+    },
+
+    initialize() {
+      //Enviamos señal sin cambio a map
+      this.activeTab = 0;
+
+      //Evita crear claves duplicadas en el array de errores
+      this.errores = [];
+      if (this.errores.length == 0) {
+        this.getErroresFromJobBD();
+      }
+
+      //Formateo datos job a tabla
+      this.datosJobToDataTable();
+    },
+
+    getErroresFromJobBD() {
+      axios
+        .get(`${process.env.VUE_APP_API_ROUTE}/error/` + this.job.job)
+        .then((data) => {
+          this.erroresBruto = data.data.errores;
+          for (this.elemento in this.erroresBruto) {
+            this.errores.push(this.erroresBruto[this.elemento]);
+            this.errores[this.elemento].job = this.job.id_job;
+          }
+        })
+        .catch((data) => {
+          console.log(data);
+        });
+    },
+
+    closeDialog() {
+      this.activateMap(false);
+      this.dialog = false;
+      this.$emit("dialog", this.dialog);
+
+      //Borramos datos obtenidos, si no se duplican la siguiente vez que se abre
+      this.errores = [];
+      this.erroresBruto = [];
+    },
+
+  },
+
+  data() {
+    return {
+      errores: [],
+      erroresBruto: [],
+      errorHeaders: [
+        { text: "Estado", value: "estado" },
+        { text: "Error", value: "error" },
+        { text: "Tema", value: "tema_error" },
+        { text: "Tipo", value: "tipo_error" },
+        { text: "Descripcion", value: "descripcion" },
+        { text: "Procedencia", value: "via_ent" },
+        { text: "Acciones", value: "actions" },
+      ],
+
+      jobHeaders: [
+        { text: "Estado", value: "estado" },
+        { text: "Expediente", value: "expediente" },
+        { text: "Perfil", value: "arreglo_job" },
+        { text: "Detectado en", value: "deteccion_job" },
+        { text: "Gravedad", value: "gravedad_job" },
+        { text: "Asignado a", value: "asignacion_job" },
+        { text: "Operador", value: "nombre_operador" },
+        { text: "Descripción", value: "descripcion" },
+      ],
+
+      mapReset: false,
+      mapIsActive: false,
+      activeTab: 0,
+
+      showMessage: false,
+      messageType: "", //green para success, red para error, blue para info.
+      message: "",
+
+      showEditJob: false,
+      jobEditar: null,
+      edicionSinGuardar: false,
+
+      //CAPACIDAD EDICION JOBS
+      editandoJob: this.job,
+
+      //ALERTA DATOS SIN GUARDAD
+      showAlert: false,
+
+      //ALERTA BORRADO ERRORES
+      showAlertError: false,
+
+      //LOGGER
+      loggerIsActive: false,
+    };
+  },
+};
+</script>
+
+<style scoped>
+.card {
+  height: 87vh;
+  padding: 0.5rem;
+}
+
+.editJobTitle, .tab, h2 {
+  font-weight: 400 !important;
+}
+
+.generateBtn {
+  background-color: #10b981;
+}
+
+.dataTable {
+  margin: 1rem 1rem 2rem 1rem;
+  padding: 1rem;
+  background-color: #eceff1;
+  border-radius: 3px;
+}
+
+/* ALERTA DATOS SIN GUARDAR */
+.alertButtonGroup {
+  margin: 0 auto;
+}
+
+.alertButton {
+  width: 10rem;
+  margin: 1rem;
+}
+
+</style>

--- a/src/components/generadorJobs/JobsTriajeGJ.vue
+++ b/src/components/generadorJobs/JobsTriajeGJ.vue
@@ -73,7 +73,7 @@
           item-key="job"
           show-select>
           <template v-slot:top>
-            <!-- VENTANA EDICION INCIDENCIA -->
+            <!-- VENTANA EDICION JOB -->
             <v-dialog
               style="heigth:100vh;"
               v-model="dialog"

--- a/src/components/operadorEsp/BandejaOpEsp.vue
+++ b/src/components/operadorEsp/BandejaOpEsp.vue
@@ -1,13 +1,17 @@
 <template>
   <div class="panelContainer">
+    <!-- HEADER -->
     <div class="panelHeader">
-      <h2 class="panelHeader-title">Bandeja de Jobs (Operadores Especializados)</h2>
+      <h2 class="panelHeader-title">
+        Bandeja de Jobs (Operadores Especializados)
+      </h2>
       <v-spacer></v-spacer>
       <v-btn title="Obtener Ayuda" tile icon color="primary" elevation="1">
         <v-icon x-large>mdi-help-box</v-icon>
       </v-btn>
     </div>
 
+    <!-- CONTAINER -->
     <div>
       <!-- PANEL ACCIONES SUPERIOR -->
       <v-card elevation="0">
@@ -15,21 +19,13 @@
           <v-col cols="12" md="8">
             <v-row class="buttonGroup">
               <v-col cols="12" md="3">
-                <v-btn 
-                  class="btn"
-                  dark 
-                  color="success"
-                >
-                ACCION 1
+                <v-btn class="btn" dark color="success">
+                  ASIGNARME JOBS
                 </v-btn>
               </v-col>
               <v-col cols="12" md="3">
-                <v-btn 
-                  class="btn"
-                  dark 
-                  color="success"
-                >
-                ACCION 2
+                <v-btn class="btn" dark color="error">
+                  DEVOLVER JOBS
                 </v-btn>
               </v-col>
               <v-spacer></v-spacer>
@@ -59,50 +55,66 @@
         item-key="job"
         show-select
       >
+
+        <!-- VENTANA DATOS JOB, LOCALIZACION EN MAPA, PROCESO -->
         <template v-slot:top>
-          <v-dialog v-model="dialogDelete" max-width="500px">
-            <v-card>
-              <h1>ATENCIÓN</h1>
-              <h3>
-                Esta acción borrará la incidencia ¿Desea continuar?
-              </h3>
-              <v-card-actions>
-                <v-spacer></v-spacer>
-                <v-btn dark text @click="closeDelete">Cancel</v-btn>
-                <v-btn dark text @click="deleteItemConfirm">OK</v-btn>
-                <v-spacer></v-spacer>
-              </v-card-actions>
-            </v-card>
+          <v-dialog
+            style="heigth:100vh;"
+            v-model="dialog"
+            persistent
+            fullscreen
+            hide-overlay
+            transition="dialog-bottom-transition"
+          >
+            <VerJob :job="editedItem" @dialog="dialogClose"></VerJob>
           </v-dialog>
         </template>
 
+        <!-- ACCIONES -->
         <template v-slot:[`item.actions`]="{ item }">
-          <v-btn title="ver datos del job" icon dark>
-            <v-icon small @click="editItem(item)"> mdi-eye </v-icon>
+          <v-btn title="Ver Job" 
+            icon dark class="editButton" @click="editItem(item)">
+            <v-icon> mdi-briefcase-eye </v-icon>
           </v-btn>
-          <v-btn title="asignarme el job" icon dark>
-            <v-icon small @click="editItem(item)">
-              mdi-account-hard-hat
-            </v-icon>
+          <v-btn title="asignarme el job" 
+            icon dark class="generateBtn" @click="asignJob(item)">
+            <v-icon>mdi-thumb-up</v-icon>
           </v-btn>
         </template>
 
+        <!-- NO DATA -->
         <template v-slot:no-data>
-            <NoData :mensaje="noDataMensaje" :opcion="noDataOpcion"></NoData>
+          <NoData :mensaje="noDataMensaje" :opcion="noDataOpcion"></NoData>
         </template>
 
+        <!-- COLORES ESTADO  -->
         <template v-slot:[`item.estado`]="{ item }">
           <v-chip :color="getColor(item.estado)" dark>
             {{ item.estado }}
           </v-chip>
         </template>
 
+        <!-- ICONOS BLOQUEO  -->
         <template v-slot:[`item.bloqueado`]="{ item }">
           <v-icon v-if="checkBlocking(item.bloqueado) == false" color="red">
             mdi-block-helper
           </v-icon>
         </template>
       </v-data-table>
+
+      <!-- MENSAJES DE INFORMACIÓN -->
+      <!--MENSAJES DE INFORMACION-->
+      <v-overlay :value="showMessage">
+        <v-alert
+          :color="messageType"
+          dark
+          border="top"
+          icon="mdi-alert-circle-outline"
+          transition="scale-transition"
+        >
+          {{ message }}
+        </v-alert>
+      </v-overlay>
     </div>
   </div>
 </template>
@@ -112,11 +124,12 @@ import axios from "axios";
 import { getColor } from "@/assets/mixins/getColor.js";
 import { checkBlocking } from "@/assets/mixins/checkBlocking.js";
 import NoData from "@/components/common/NoData";
+import VerJob from "@/components/common/VerJob";
 
 export default {
   name: "BandejaOpEsp",
   mixins: [getColor, checkBlocking],
-  components: {NoData},
+  components: { NoData, VerJob },
 
   data: () => ({
     dialog: false,
@@ -163,6 +176,11 @@ export default {
     //NO DATA SLOT
     noDataMensaje: "Vaya... parece que no existen jobs para mostrar aquí.",
     noDataOpcion: "Si necesitas jobs para trabajar puedes generar alguna IDV",
+
+    //MENSAJES INFORMACIÓN
+    showMessage: false,
+    message: '',
+    messageType: '',
   }),
 
   computed: {
@@ -190,20 +208,56 @@ export default {
       console.log();
     },
 
+    asignJob(job){
+      job.nuevoEstado = 'En bandeja_op';
+      job.nombre_operador = localStorage.usuario;
+      
+      //OBJECTO LOG
+      this.log = {
+          idEventoLogger: 11, //JOB SELECCIONADO PARA TRABAJAR
+          procesoJob: 'GOT',
+          usuario: localStorage.usuario,
+          observaciones: '',
+          departamento: '',
+          resultadoCC: '',
+      }
+
+      axios
+      .post(`${process.env.VUE_APP_API_ROUTE}/cambioEstadosJob`, [job, this.log])
+      .then((data) => {
+        for (this.index in this.jobs){
+          if (this.jobs[this.index].job == data.data.jobActualizado){
+            this.jobs.splice(this.index, 1)
+            this.message = `Te has asignado correctamente el job ${data.data.jobActualizado}`
+            this.messageType = 'success';
+            this.showMessage = true;
+            setTimeout(this.closeInfoMsg, 2000);
+          }
+        }
+      })
+    },
+
+    closeInfoMsg(){
+      this.showMessage = false;
+    },
+
     editItem(item) {
       this.editedIndex = this.jobs.indexOf(item);
       this.editedItem = Object.assign({}, item);
-      console.log(this.editedItem);
+      this.dialog = true;
     },
 
     initialize() {
-      axios.get(`${process.env.VUE_APP_API_ROUTE}/jobs`).then((data) => {
+      axios
+      .get(`${process.env.VUE_APP_API_ROUTE}/jobs`)
+      .then((data) => {
         this.jobsBruto = data.data.response;
         for (this.elemento in this.jobsBruto) {
           //filtramos jobs, en bandeja, operadores sin operador asignado
           if (
             this.jobsBruto[this.elemento].estado == "En bandeja" &&
-            this.jobsBruto[this.elemento].tipo_bandeja == "Operadores Especializados" &&
+            this.jobsBruto[this.elemento].tipo_bandeja ==
+              "Operadores Especializados" &&
             this.jobsBruto[this.elemento].nombre_operador == null
           ) {
             this.jobs.push(this.jobsBruto[this.elemento]);
@@ -260,12 +314,13 @@ export default {
   min-height: 1vh !important;
 }
 
-h2, h4 {
+h2,
+h4 {
   font-family: 300 !important;
 }
 
 .panelContainer {
-  background-color:white;
+  background-color: white;
   padding: 2rem;
   border-radius: 10px;
   box-shadow: 2px 2px 6px 2px rgba(0, 0, 0, 0.2);
@@ -275,11 +330,10 @@ h2, h4 {
   display: flex;
 }
 
-.panelHeader-title{
+.panelHeader-title {
   font-weight: 500;
   margin-bottom: 2rem;
 }
-
 
 .panelFuncionesCard {
   background-color: #4287f5;
@@ -298,6 +352,8 @@ h2, h4 {
   padding: 1rem;
 }
 
-
-
+.saveButton {
+  background-color: #4287f5;
+  margin-right: 0.25rem;
+}
 </style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -300,27 +300,27 @@ h2.active {
 }
 
 .fadeIn.first {
+  -webkit-animation-delay: 0.2s;
+  -moz-animation-delay: 0.2s;
+  animation-delay: 0.2s;
+}
+
+.fadeIn.second {
+  -webkit-animation-delay: 0.3s;
+  -moz-animation-delay: 0.3s;
+  animation-delay: 0.3s;
+}
+
+.fadeIn.third {
   -webkit-animation-delay: 0.4s;
   -moz-animation-delay: 0.4s;
   animation-delay: 0.4s;
 }
 
-.fadeIn.second {
-  -webkit-animation-delay: 0.6s;
-  -moz-animation-delay: 0.6s;
-  animation-delay: 0.6s;
-}
-
-.fadeIn.third {
-  -webkit-animation-delay: 0.8s;
-  -moz-animation-delay: 0.8s;
-  animation-delay: 0.8s;
-}
-
 .fadeIn.fourth {
-  -webkit-animation-delay: 1s;
-  -moz-animation-delay: 1s;
-  animation-delay: 1s;
+  -webkit-animation-delay: 0.5s;
+  -moz-animation-delay: 0.5s;
+  animation-delay: 0.5s;
 }
 
 /* Simple CSS3 Fade-in Animation */


### PR DESCRIPTION
Añadidas las funciones básicas en las bandejas de operadores y operadores especializados. 

- **Ver job** : Incluye información de jobs y errores, visualización en mapa (sin capacidad de edición) y eventos de log funcionales.
- **Asignación de jobs:** desde las bandejas genéricas de operador y operador especializado ahora es posible que el usuario se asigne los jobs con los que desea trabajar.
- **Devolución de jobs:** desde la bandeja del usuario con rol operador u operador especializado ahora es posible devolver aquellos jobs con los que no se desea trabajar. Incluye una ventana para introducir justificaciones a esta devolución.