### PR TITLE
Refactoring a la parte de edicion y alta de jobs errores

### DIFF
--- a/src/components/common/AccionesDisponibles.vue
+++ b/src/components/common/AccionesDisponibles.vue
@@ -2,8 +2,13 @@
     <div class="actionsWrapper" v-if="loadAction != true">
         <!-- JOB SELECCIONADO PARA TRABAJAR || JOB GENERADO DIRECTO A OPERADOR -->
         <div v-if="accion =='JST' || accion =='JAO' || accion =='JGE' && job.nombre_operador != null">
-            <v-btn class="actionBtn" block color="success" @click="createVersion">Solicitar Versión</v-btn>
-            <v-btn class="actionBtn" block color="error" @click="showDevolverWindow = true">Devolver a Bandeja</v-btn>
+            <div v-if="activeRole === 'Operador' || activeRole === 'Operador Especializado'">
+                <v-btn class="actionBtn" block color="success" @click="createVersion">Solicitar Versión</v-btn>
+                <v-btn class="actionBtn" block color="error" @click="showDevolverWindow = true">Devolver a Bandeja</v-btn>
+            </div>
+            <div v-else>
+                <v-alert dense type="success">Job generado correctamente</v-alert>
+            </div>
         </div>
 
         <!-- JOB GENERADO A BANDEJA GENÉRICA -->

--- a/src/components/common/AsignarErrores.vue
+++ b/src/components/common/AsignarErrores.vue
@@ -107,7 +107,6 @@
 
 <script>
 import Map from "@/components/common/Map";
-import {stringifyErrorGeometry} from "@/assets/mixins/stringifyErrorGeometry";
 import {getColor} from "@/assets/mixins/getColor";
 import axios from 'axios';
 
@@ -115,7 +114,7 @@ export default {
   name: "AsignarErrores",
   components: { Map },
   props: ["errores"],
-  mixins: [stringifyErrorGeometry, getColor],
+  mixins: [getColor],
 
   data() {
     return {
@@ -181,10 +180,6 @@ export default {
         departamento: "",
         resultadoCC: "",
       };
-
-      for (this.index in this.erroresAsign){
-        this.erroresAsign[this.index].geometria = this.stringifyErrorGeometry(this.erroresAsign[this.index].geometria_json)
-      }
 
       this.jobsErrores = {
         jobs: this.jobsAsign,

--- a/src/components/common/BandejaMisJobs.vue
+++ b/src/components/common/BandejaMisJobs.vue
@@ -284,12 +284,11 @@ export default {
             this.jobsBruto[this.elemento].estado == "Pausa" ||
             this.jobsBruto[this.elemento].estado == "Ejecución" ||
             this.jobsBruto[this.elemento].estado === "Error_fin para usuario"          
-            &&
-            this.jobsBruto[this.elemento].nombre_operador ==
-              localStorage.usuario
-          ) {
-            this.jobs.push(this.jobsBruto[this.elemento]);
-          }
+            ) {
+              if (this.jobsBruto[this.elemento].nombre_operador == localStorage.usuario){
+                this.jobs.push(this.jobsBruto[this.elemento]);
+              }
+            }
         }
       });
     },

--- a/src/components/common/DatosJobErrores.vue
+++ b/src/components/common/DatosJobErrores.vue
@@ -1,0 +1,218 @@
+<template>
+  <v-card class="card" flat>
+    <div class="dataTable">
+      <h2>Jobs</h2>
+      <v-data-table
+        :headers="jobHeaders"
+        :items="job"
+        item-key="job"
+        hide-default-footer
+      >
+        <template v-slot:[`item.estado`]="{ item }">
+          <v-chip :color="getColor(item.estado)" dark>
+            {{ item.estado }}
+          </v-chip>
+        </template>
+      </v-data-table>
+    </div>
+
+    <div class="dataTable">
+      <h2>Errores Asociados</h2>
+      <v-data-table
+        calculate-widths
+        :headers="errorHeaders"
+        :items="errores"
+        item-key="error"
+        hide-default-footer
+      >
+        <template v-slot:[`item.estado`]="{ item }">
+          <v-chip :color="getColor(item.estado)" dark>
+            {{ item.estado }}
+          </v-chip>
+        </template>
+
+        <template v-slot:no-data>
+          <h2 class="errorNoData">No existen errores asociados al job</h2>
+        </template>
+
+        <template v-slot:[`item.actions`]="{ item }">
+          <v-btn class="errorBtn" title="Eliminar Error" icon dark>
+            <v-icon @click="confirmDelete(item)">
+              mdi-trash-can
+            </v-icon>
+          </v-btn>
+        </template>
+      </v-data-table>
+    </div>
+
+    <!-- AVISO ELIMINAR ERRORES -->
+    <v-overlay :value="showAlertError">
+      <v-card class="alertCard">
+        <h1 class="alertCardTitle">ATENCIÓN</h1>
+        <h4>Esta acción borrara el error.</h4>
+        <h4>El borrado es permanente y <b>no puede deshacerse</b>.</h4>
+        <br />
+        <h3><b>¿Desea continuar?</b></h3>
+        <v-card-actions>
+          <div class="alertButtonGroup">
+            <v-btn
+              class="alertButton errorBtn"
+              dark
+              text
+              @click="showAlertError = false"
+            >
+              CANCELAR
+            </v-btn>
+            <v-btn
+              class="alertButton generateBtn"
+              dark
+              text
+              @click="deleteError(errorBorrar)"
+            >
+              OK
+            </v-btn>
+          </div>
+        </v-card-actions>
+      </v-card>
+    </v-overlay>
+
+    <!--MENSAJES DE INFORMACION-->
+    <v-overlay :value="showMessage">
+      <v-alert
+        :color="messageType"
+        dark
+        border="top"
+        icon="mdi-alert-circle-outline"
+        transition="scale-transition"
+      >
+        {{ message }}
+      </v-alert>
+    </v-overlay>
+  </v-card>
+</template>
+
+<script>
+import axios from "axios";
+import { getColor } from "@/assets/mixins/getColor";
+
+export default {
+  name: "DatosJobErrores",
+  props: ["job", "errores"],
+  mixins: [getColor],
+
+  data() {
+    return {
+      errorHeaders: [
+        { text: "Estado", value: "estado" },
+        { text: "Error", value: "error" },
+        { text: "Tema", value: "tema_error" },
+        { text: "Tipo", value: "tipo_error" },
+        { text: "Descripcion", value: "descripcion" },
+        { text: "Procedencia", value: "via_ent" },
+        { text: "Acciones", value: "actions" },
+      ],
+
+      jobHeaders: [
+        { text: "Estado", value: "estado" },
+        { text: "Expediente", value: "expediente" },
+        { text: "Perfil", value: "arreglo_job" },
+        { text: "Detectado en", value: "deteccion_job" },
+        { text: "Gravedad", value: "gravedad_job" },
+        { text: "Asignado a", value: "asignacion_job" },
+        { text: "Operador", value: "nombre_operador" },
+        { text: "Descripción", value: "descripcion" },
+      ],
+
+      //ALERTA BORRADO ERRORES
+      showAlertError: false,
+      messageType: "", //green para success, red para error, blue para info.
+      message: "",
+
+      //MENSAJES DE INFORMACION
+      showMessage: false,
+    };
+  },
+
+  methods: {
+    confirmDelete(errorBorrar) {
+      this.showAlertError = true;
+      this.errorBorrar = errorBorrar;
+    },
+
+    deleteError(error) {
+      //OBJECTO LOG
+      this.log = {
+          idEventoLogger: 32, //ERROR DESESTIMADO GENERADOR DE JOBS
+          procesoJob: 'GOT',
+          usuario: localStorage.usuario,
+          observaciones: 'Error eliminado en Triaje',
+          departamento: '',
+          resultadoCC: '',
+      }
+
+      if (error.error != null) {
+        axios
+          .delete(`${process.env.VUE_APP_API_ROUTE}/deleteError`, {
+            data: { error: error, log: this.log },
+          })
+          .then((data) => {
+            if (data.status == 201) {
+              this.showInfo(data.data.mensaje, "green");
+              setTimeout(this.closeInfo, 1000);
+
+              //Actualizar array errores
+              for (this.index in this.errores) {
+                if (this.errores[this.index].error == error.error) {
+                  this.errores.splice(this.index, 1);
+                }
+              }
+            } else {
+              this.showInfo(data.data.mensaje, "red");
+              setTimeout(this.closeInfo, 2000);
+            }
+          });
+      } else {
+        this.showInfo("Error eliminado correctamente", "green");
+        setTimeout(this.closeInfo, 2000);
+        //Actualizar array errores
+        for (this.index in this.errores) {
+          if (this.errores[this.index].error == error.error) {
+            this.errores.splice(this.index, 1);
+          }
+        }
+      }
+      this.showAlertError = false;
+    },
+
+    showInfo(message, type) {
+      this.showMessage = true;
+      this.message = message;
+      this.messageType = type;
+    },
+
+    closeInfo() {
+      this.showMessage = false;
+    },
+  },
+};
+</script>
+
+<style scoped>
+h2 {
+  font-weight: 400 !important;
+}
+
+.card {
+  height: 87vh;
+  padding: 0.5rem;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.dataTable {
+  margin: 1rem 1rem 2rem 1rem;
+  padding: 1rem;
+  background-color: #eceff1;
+  border-radius: 3px;
+}
+</style>

--- a/src/components/common/Map.vue
+++ b/src/components/common/Map.vue
@@ -123,7 +123,7 @@
                     >
                         <vl-overlay
                         class="showIdErrorContainer"
-                        :position="atribute.geometria_json.coordinates"
+                        :position="atribute.geometria.coordinates"
                         :offset="[-48, -45]">
                             <p>
                                 {{atribute.error}}
@@ -701,8 +701,7 @@ import {v4 as uuidv4} from 'uuid';
 import { makeArrayFromApi } from '@/assets/mixins/makeArrayFromApi';
 import { asignarValoresDefault } from '@/assets/mixins/asignarValoresDefault';
 import { getMapExtent } from '@/assets/mixins/getMapExtent';
-import { stringifyJobGeometry } from '@/assets/mixins/stringifyJobGeometry';
-import { stringifyErrorGeometry } from '@/assets/mixins/stringifyErrorGeometry';
+
 
 import FormularioDatosJob from '@/components/common/FormularioDatosJob';
 import FormularioDatosError from '@/components/common/FormularioDatosError';
@@ -732,8 +731,6 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
             makeArrayFromApi, 
             asignarValoresDefault,
             getMapExtent,
-            stringifyJobGeometry,
-            stringifyErrorGeometry,
         ],
 
         created(){
@@ -742,7 +739,7 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
             this.getJobParameters();
             this.getErrorParameters();
             this.retrieveJobFromBD();
-            this.retrieveErrorsFromBD();         
+            this.retrieveErrorsFromBD();
         },
 
 
@@ -782,7 +779,10 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
                     if(this.jobsAttrb.length > 0){
                         for (this.index in this.jobs){
                             if (this.jobs[this.index].id == this.jobsAttrb[this.index].id){
-                                this.jobsAttrb[this.index].geometria_json = this.jobs[this.index].geometry;
+                                if (this.jobs[this.index].geometry.coordinates != this.jobsAttrb[this.index].geometria.coordinates){
+                                    this.jobsAttrb[this.index].editado = true;
+                                    this.jobsAttrb[this.index].geometria = this.jobs[this.index].geometry;
+                                }
                             }
                         }
                     }
@@ -802,8 +802,8 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
                 if(this.errores.length == this.erroresAttrb.length){
                     for (this.index in this.errores){
                         for (this.indexAttrb in this.erroresAttrb){
-                            if (this.errores[this.index].id == this.erroresAttrb[this.indexAttrb].id) {
-                                this.erroresAttrb[this.index].geometria_json = this.errores[this.index].geometry;
+                            if (this.errores[this.index].id === this.erroresAttrb[this.indexAttrb].id) {
+                                this.erroresAttrb[this.index].geometria = this.errores[this.index].geometry;
                             }
                         }
                     }
@@ -825,7 +825,7 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
                 for (this.index in this.erroresAttrb){
                     if (this.erroresAttrb[this.index].id==this.errorMostrarInfo.id){
                         this.erroresAttrb[this.index] = this.errorMostrarInfo
-                        this.erroresAttrb[this.index].geometria = this.stringifyErrorGeometry(this.errorMostrarInfo.geometria_json)
+                        this.erroresAttrb[this.index].geometria = this.errorMostrarInfo.geometria
                     }
                 }
                 this.$emit("errores", this.erroresAttrb)
@@ -863,8 +863,7 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
                                         via_ent: this.errorSeleccionado.via_ent,
                                         estado: this.errorSeleccionado.estado,
                                         job: this.errorSeleccionado.job,
-                                        geometria: null,
-                                        geometria_json: this.errorSeleccionado.geometria_json,
+                                        geometria: this.errorSeleccionado.geometria,
                                     }
                                 }
                             }
@@ -887,7 +886,7 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
                                 if (this.jobsAttrb[this.indexattrb].id == this.selectedJobs[this.index].id){
                                     this.jobMostrarInfo = this.jobsAttrb[this.indexattrb];
                                     //Reiniciamos la geometría por si fuera necesario hacer ediciones
-                                    this.jobMostrarInfo.geometria = this.stringifyJobGeometry(this.jobsAttrb[this.indexattrb].geometria_json)
+                                    this.jobMostrarInfo.geometria = this.selectedJobs[this.index].geometry;
                                 }
                             }
                         }
@@ -906,7 +905,7 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
                         //Geometrias
                         this.newJob = {
                             id: uuidv4(),
-                            geometry: this.jobsRecibidos.geometria_json,
+                            geometry: {coordinates: this.jobsRecibidos.geometria.coordinates, type: this.jobsRecibidos.geometria.type},
                             type: "Feature"
                         }
                         this.jobs.push(this.newJob);
@@ -925,7 +924,6 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
                             asignacion_job: this.jobsRecibidos.asignacion_job,
                             nombre_operador: this.jobsRecibidos.nombre_operador,
                             geometria: this.jobsRecibidos.geometria,
-                            geometria_json: this.jobsRecibidos.geometria_json,
                             job_grande: this.jobsRecibidos.job_grande,
                         };
                         this.jobsAttrb.push(this.newAttrbJobBd);
@@ -953,7 +951,7 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
                         for (this.index in this.erroresRecibidos){
                             this.newError = {
                                 id: uuidv4(),
-                                geometry: this.erroresRecibidos[this.index].geometria_json,
+                                geometry: {coordinates: this.erroresRecibidos[this.index].geometria.coordinates, type: this.erroresRecibidos[this.index].geometria.type},
                                 type: "Feature"
                             }
                             this.errores.push(this.newError);
@@ -969,8 +967,7 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
                                 tipo_error: this.erroresRecibidos[this.index].tipo_error,
                                 via_ent: this.erroresRecibidos[this.index].via_ent,
                                 estado: this.erroresRecibidos[this.index].estado,
-                                geometria: null,
-                                geometria_json: this.erroresRecibidos[this.index].geometria_json,
+                                geometria: this.erroresRecibidos[this.index].geometria,
                             };
                             this.erroresAttrb.push(this.newAttrbErrorBd);
                         }
@@ -1072,26 +1069,7 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
                     })
             },
 
-            storeAttrbErrors(){
-                //Almacenamos los atributos de cada job en un array distinto
-                //TODO: parece imposible unificar todo en un mismo array... 
-                let newAttrbError = {
-                    id: this.errores[this.errores.length-1].id,
-                    id_error: null,
-                    error: null,
-                    descripcion: this.descError,
-                    job: null,
-                    tema_error: this.selectTema,
-                    tipo_error: this.selectTipoError,    
-                    via_ent: 'IDV',
-                    estado: 'Marcado',
-                    geometria: this.stringifyErrorGeometry(this.errores[this.errores.length-1].geometry),
-                    geometria_json: this.errores[this.errores.length-1].geometry,            
-                }
-                this.erroresAttrb.push(newAttrbError);
-                this.editError = false;
-                this.$emit('errores', this.erroresAttrb)
-            },
+            
 
             getJobParameters(){
                 axios.get(`${process.env.VUE_APP_API_ROUTE}/jobParameters`).then((data) => {
@@ -1191,13 +1169,34 @@ import FormularioDatosError from '@/components/common/FormularioDatosError';
                     tipo_bandeja: this.tipoBandejaJob,
                     asignacion_job: this.asignacionJob,
                     nombre_operador: this.nombreOperadorJob,
-                    geometria: this.stringifyJobGeometry(this.jobs[this.jobs.length-1].geometry),
-                    geometria_json: this.jobs[this.jobs.length-1].geometry,
+                    geometria: this.jobs[this.jobs.length-1].geometry,
                     job_grande: this.jobGrande,
+                    editado: true,
                 }
                 this.jobsAttrb.push(this.newAttrbJob);
                 this.editJob = false;
                 this.$emit('jobs', this.jobsAttrb)
+            },
+
+            storeAttrbErrors(){
+                //Almacenamos los atributos de cada job en un array distinto
+                //TODO: parece imposible unificar todo en un mismo array... 
+                let newAttrbError = {
+                    id: this.errores[this.errores.length-1].id,
+                    id_error: null,
+                    error: null,
+                    descripcion: this.descError,
+                    job: null,
+                    tema_error: this.selectTema,
+                    tipo_error: this.selectTipoError,    
+                    via_ent: 'IDV',
+                    estado: 'Marcado',
+                    geometria: this.errores[this.errores.length-1].geometry,
+                    editado: true,            
+                }
+                this.erroresAttrb.push(newAttrbError);
+                this.editError = false;
+                this.$emit('errores', this.erroresAttrb)
             },
 
             activeDrawJobs(){

--- a/src/components/generadorJobs/ErroresNoAsign.vue
+++ b/src/components/generadorJobs/ErroresNoAsign.vue
@@ -329,7 +329,7 @@ export default {
         })
         .catch((data) => {
           console.log(data)
-        })
+      })
     },
 
     editItem(item) {

--- a/src/components/generadorJobs/JobsTriajeGJ.vue
+++ b/src/components/generadorJobs/JobsTriajeGJ.vue
@@ -516,9 +516,7 @@ export default {
     confirmDeleteJobs() {
       const deleteJobs = this.selected;
       axios
-        .delete(`${process.env.VUE_APP_API_ROUTE}/deleteJobs`, {
-          data: deleteJobs,
-        })
+        .delete(`${process.env.VUE_APP_API_ROUTE}/deleteJobs`, {data: deleteJobs,})
         .then((data) => {
           if (data.status == 201) {
             this.showInfo(data.data.mensaje, "green");
@@ -527,10 +525,7 @@ export default {
             //Actualizar array jobs
             for (this.index in this.jobs) {
               for (this.indexSelection in this.selected) {
-                if (
-                  this.selected[this.indexSelection].id_job ==
-                  this.jobs[this.index].id_job
-                ) {
+                if (this.selected[this.indexSelection].id_job === this.jobs[this.index].id_job) {
                   this.jobs.splice(this.index, 1);
                 }
               }

--- a/src/components/generadorJobs/altaJobsErrores.vue
+++ b/src/components/generadorJobs/altaJobsErrores.vue
@@ -169,20 +169,22 @@
 </template>
 
 <script>
+
 import Map from "@/components/common/Map";
 import axios from "axios";
-import { getColor } from "@/assets/mixins/getColor.js";
-import { generarJobError } from "@/assets/mixins/generarJobError.js";
+import { getColor } from "@/assets/mixins/getColor";
+import { generarJobError } from "@/assets/mixins/generarJobError";
+
+import { stringifyJobGeometry } from "@/assets/mixins/stringifyJobGeometry";
+import { stringifyErrorGeometry } from "@/assets/mixins/stringifyErrorGeometry";
 
 export default {
   name: "altaJobsErrores",
 
-  components: {
-    Map,
-  },
+  components: { Map },
 
-  mixins: [getColor, generarJobError],
-
+  mixins: [getColor, generarJobError, stringifyJobGeometry, stringifyErrorGeometry],
+  
   watch: {
     selectViaEntrada() {
       this.viaEntrada = this.selectViaEntrada;
@@ -220,40 +222,32 @@ export default {
         this.closeDialog();
       }
     },
-
     openAlert() {
       this.showAlert = true;
     },
-
     closeAlert() {
       this.showAlert = false;
     },
-
     closeDialog() {
       this.dialog = false;
       //Al cerrar el dialogo devuelve el valor por defecto para GJ a loader
       //TODO: habría que definir el valor por defecto en una función global
       this.$emit("closed", "JobsTriajeGJ");
     },
-
     showInfo(message, type) {
       this.showMessage = true;
       this.message = message;
       this.messageType = type;
     },
-
     closeInfo() {
       this.showMessage = false;
     },
-
     storeJobs(jobs) {
       this.jobs = jobs;
     },
-
     storeErrors(errores) {
       this.errores = errores;
     },
-
     // GUARDAR DATOS MAESTRO
     saveData() {
       this.showLoading = true;
@@ -264,12 +258,13 @@ export default {
         departamento: "",
         resultadoCC: "",
       };
+
       this.jobsErrores = {
         jobs: this.jobs,
         errores: this.errores,
         log: this.log,
       };
-
+      
       axios
         .post(
           `${process.env.VUE_APP_API_ROUTE}/postJobsErrores`,
@@ -289,12 +284,13 @@ export default {
                   data.data.errores[this.asignIndex].idInterno ==
                     this.errores[this.index].id
                 ) {
-                  this.errores[this.index].asocJob = data.data.errores[this.asignIndex].job;
-                  this.errores[this.index].idError = data.data.errores[this.asignIndex].codigoError;
+                  this.errores[this.index].asocJob =
+                    data.data.errores[this.asignIndex].job;
+                  this.errores[this.index].idError =
+                    data.data.errores[this.asignIndex].codigoError;
                 }
               }
             }
-
             this.datosGuardados = true;
             this.showLoading = false;
             this.showInfo("Datos guardados correctamente", "green");
@@ -303,11 +299,9 @@ export default {
           } else {
             console.log(data.data.mensaje);
           }
-      });
-      
+        });
     },
   },
-
   data() {
     return {
       dialog: true,
@@ -318,7 +312,6 @@ export default {
       showMessage: false, //Muestra mensajes de información en la parte inferior de la pantalla
       message: "", //Determina el texto mostrado en el mensaje de información
       messageType: "", //green para success, red para error, blue para info.
-
       jobHeaders: [
         { text: "Estado", value: "estado" },
         { text: "ID Job", value: "job" },
@@ -330,7 +323,6 @@ export default {
         { text: "Operador", value: "nombre_operador" },
         { text: "Descripción", value: "descripcion" },
       ],
-
       errorHeaders: [
         { text: "Estado", value: "estado" },
         { text: "Id Error", value: "idError" },
@@ -339,10 +331,8 @@ export default {
         { text: "Tema Error", value: "tema_error" },
         { text: "Descripcion", value: "descripcion" },
       ],
-
       showAlert: false, //Muestra ventana de alerta
       datosGuardados: false, //Indica si los datos han sido guardados en base de datos.
-
       showLoading: false, //Muestra la pantalla de carga mientras los datos son almacenados
     };
   },
@@ -353,37 +343,29 @@ export default {
 .dialogContainer {
   height: 93vh;
 }
-
 .toolbarBtn {
   margin: auto 0.5rem;
   font-weight: 400 !important;
 }
-
 .tab {
   font-weight: 400 !important;
 }
-
 .cardMap {
-  height: 88vh;
+  height: 87vh;
 }
-
 .cardJob {
   height: 86vh;
   overflow-y: auto;
 }
-
 .cardJob > * > h2 {
   font-weight: 400 !important;
 }
-
 .errorBtn {
   background-color: #ef4444;
 }
-
 .saveBtn {
   background-color: #10b981;
 }
-
 /* RESUMEN JOBS ERRORES */
 .dataTable {
   margin: 1rem 1rem 2rem 1rem;
@@ -391,25 +373,20 @@ export default {
   background-color: #eceff1;
   border-radius: 3px;
 }
-
 /*ALERTA DATOS NO GUARDADOS */
 .alertCard {
   text-align: center;
   padding: 1rem;
 }
-
 .alertCardTitle {
   margin-bottom: 0.5rem;
 }
-
 .alertCard > * {
   font-weight: 400 !important;
 }
-
 .alertButtonGroup {
   margin: 0 auto;
 }
-
 .alertButton {
   width: 10rem;
   margin: 1rem;


### PR DESCRIPTION
Se ha llevado a cabo un refactoring para la parte de edición de jobs y alta de jobs / errores. Se han simplificado las clases y ahora los tres componentes hijos de EditandoJob comparten un único espacio de Data para aprovechar la capacidad reactiva de Vue. 

Además se ha eliminado la dependencia del campo geometria_json. Ahora es la API la que se encarga de servir y transformar los datos entre el espacio de trabajo de GOT (GeoJSON) y la BD (postgis). 